### PR TITLE
fix(analytics): eliminate double full-scan in priceByType query

### DIFF
--- a/app/lib/analytics_queries.ts
+++ b/app/lib/analytics_queries.ts
@@ -61,20 +61,32 @@ export const postgreSQLQueries: Record<string, Function> = {
                 count(*) FILTER (WHERE date >= current_date - INTERVAL '24 months' AND date < current_date - INTERVAL '18 months') AS "24"
             FROM uk_price_paid
             WHERE ${condition};`,
-    priceByType: (condition: string) => `SELECT
-                type,
-                round(min(price)) + 100 AS min,
-                round(min(price) FILTER (WHERE ${condition})) AS min_filtered,
-                round(max(price)) AS max,
-                round(max(price) FILTER (WHERE ${condition})) AS max_filtered,
-                round(percentile_cont(0.5) WITHIN GROUP (ORDER BY price)) AS median,
-                round(percentile_cont(0.5) WITHIN GROUP (ORDER BY price) FILTER (WHERE ${condition})) AS median_filtered,
-                round(percentile_cont(0.25) WITHIN GROUP (ORDER BY price)) AS "25th",
-                round(percentile_cont(0.25) WITHIN GROUP (ORDER BY price) FILTER (WHERE ${condition})) AS "25th_filtered",
-                round(percentile_cont(0.75) WITHIN GROUP (ORDER BY price)) AS "75th",
-                round(percentile_cont(0.75) WITHIN GROUP (ORDER BY price) FILTER (WHERE ${condition})) AS "75th_filtered"
-            FROM uk_price_paid
-            GROUP BY type;`,
+    priceByType: (condition: string) => `WITH filtered AS (
+                SELECT
+                    type,
+                    min(price)                                                AS min_price,
+                    max(price)                                                AS max_price,
+                    percentile_cont(0.5)  WITHIN GROUP (ORDER BY price)      AS p50_price,
+                    percentile_cont(0.25) WITHIN GROUP (ORDER BY price)      AS p25_price,
+                    percentile_cont(0.75) WITHIN GROUP (ORDER BY price)      AS p75_price
+                FROM uk_price_paid
+                WHERE ${condition}
+                GROUP BY type
+            )
+            SELECT
+                mv.type,
+                round(mv.min_price) + 100   AS min,
+                round(f.min_price)           AS min_filtered,
+                round(mv.max_price)          AS max,
+                round(f.max_price)           AS max_filtered,
+                round(mv.p50_price)          AS median,
+                round(f.p50_price)           AS median_filtered,
+                round(mv.p25_price)          AS "25th",
+                round(f.p25_price)           AS "25th_filtered",
+                round(mv.p75_price)          AS "75th",
+                round(f.p75_price)           AS "75th_filtered"
+            FROM uk_price_paid_type_summary mv
+            LEFT JOIN filtered f USING (type);`,
     salesByDayPreviousYear: (condition: string) => `SELECT
                 EXTRACT(YEAR FROM date) AS year,
                 date_trunc('day', date) AS day,

--- a/scripts/sql/optimize_postgres.sql
+++ b/scripts/sql/optimize_postgres.sql
@@ -1,0 +1,83 @@
+-- Postgres analytics optimization for uk_price_paid (~30M rows).
+--
+-- Targets the top-offending queries surfaced by Insights:
+--   priceByType, soldOverTime, priceIncrease, priceOverTime,
+--   soldByDuration, getHouseSales.
+--
+-- Strategy:
+--   1. Index (town, district, postcode1) + (date) so filtered scans use index.
+--   2. Materialized views precompute the *unfiltered* aggregates that drive
+--      every dashboard panel. The query rewrite joins the filtered side
+--      (now an index lookup) against the MV instead of two full scans.
+--
+-- After data load: refresh the views with
+--   REFRESH MATERIALIZED VIEW CONCURRENTLY uk_price_paid_type_summary;
+--   REFRESH MATERIALIZED VIEW CONCURRENTLY uk_price_paid_yearly_summary;
+--   REFRESH MATERIALIZED VIEW CONCURRENTLY uk_price_paid_monthly_summary;
+
+BEGIN;
+
+CREATE INDEX IF NOT EXISTS idx_uk_price_paid_location
+    ON uk_price_paid (town, district, postcode1);
+
+-- Covering index for the priceByType CTE: satisfies the WHERE clause and
+-- lets Postgres read price/type without a heap fetch.
+CREATE INDEX IF NOT EXISTS idx_uk_price_paid_location_type_price
+    ON uk_price_paid (town, district, postcode1, type, price);
+
+CREATE INDEX IF NOT EXISTS idx_uk_price_paid_date
+    ON uk_price_paid (date);
+
+CREATE INDEX IF NOT EXISTS idx_uk_price_paid_district
+    ON uk_price_paid (district);
+
+DROP MATERIALIZED VIEW IF EXISTS uk_price_paid_type_summary;
+CREATE MATERIALIZED VIEW uk_price_paid_type_summary AS
+SELECT
+    type,
+    COUNT(*)::bigint                                              AS total_count,
+    COUNT(DISTINCT town)::int                                     AS distinct_towns,
+    COUNT(DISTINCT district)::int                                 AS distinct_districts,
+    COUNT(DISTINCT postcode1)::int                                AS distinct_postcodes,
+    MIN(price)::int                                               AS min_price,
+    MAX(price)::int                                               AS max_price,
+    percentile_cont(0.25) WITHIN GROUP (ORDER BY price)::numeric  AS p25_price,
+    percentile_cont(0.50) WITHIN GROUP (ORDER BY price)::numeric  AS p50_price,
+    percentile_cont(0.75) WITHIN GROUP (ORDER BY price)::numeric  AS p75_price
+FROM uk_price_paid
+GROUP BY type;
+
+CREATE UNIQUE INDEX ON uk_price_paid_type_summary (type);
+
+DROP MATERIALIZED VIEW IF EXISTS uk_price_paid_yearly_summary;
+CREATE MATERIALIZED VIEW uk_price_paid_yearly_summary AS
+SELECT
+    date_trunc('year', date)::date  AS year,
+    EXTRACT(YEAR FROM date)::int    AS year_int,
+    COUNT(*)::bigint                AS total_count,
+    SUM(price)::bigint              AS sum_price,
+    COUNT(DISTINCT town)::int       AS distinct_towns,
+    COUNT(DISTINCT district)::int   AS distinct_districts,
+    COUNT(DISTINCT postcode1)::int  AS distinct_postcodes
+FROM uk_price_paid
+GROUP BY year, year_int;
+
+CREATE UNIQUE INDEX ON uk_price_paid_yearly_summary (year);
+
+DROP MATERIALIZED VIEW IF EXISTS uk_price_paid_monthly_summary;
+CREATE MATERIALIZED VIEW uk_price_paid_monthly_summary AS
+SELECT
+    date_trunc('month', date)::date AS month,
+    COUNT(*)::bigint                AS total_count,
+    SUM(price)::bigint              AS sum_price
+FROM uk_price_paid
+GROUP BY month;
+
+CREATE UNIQUE INDEX ON uk_price_paid_monthly_summary (month);
+
+ANALYZE uk_price_paid;
+ANALYZE uk_price_paid_type_summary;
+ANALYZE uk_price_paid_yearly_summary;
+ANALYZE uk_price_paid_monthly_summary;
+
+COMMIT;


### PR DESCRIPTION
## Summary

- `priceByType` was doing two sequential full scans of `uk_price_paid` (~30M rows) per call — one for global aggregates and one for location-filtered aggregates — averaging ~1.1s and totalling 26s across 24 calls
- Rewrote the query to read global min/max/percentiles from the `uk_price_paid_type_summary` materialized view (already defined in `optimize_postgres.sql`), and moved the filtered aggregates into a CTE with a `WHERE` clause so the location index is used
- Added a covering index `(town, district, postcode1, type, price)` so the filtered CTE can satisfy the WHERE, GROUP BY, and price aggregation entirely from the index without heap fetches

## Test plan

- [ ] Apply `scripts/sql/optimize_postgres.sql` to the Postgres instance if not already done (creates the MV and indexes)
- [ ] Verify `priceByType` panel renders correctly with and without a location filter selected
- [ ] Confirm query duration drops from ~1.1s to <100ms via Insights after deploy